### PR TITLE
refactor(tmr.py): ~40% performance improvement for Tmr.get_boundary_f…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ Modflow-setup is a Python package for automating the setup of MODFLOW groundwate
 
 ### Version 0.1
 ![Tests](https://github.com/usgs/modflow-setup/workflows/Tests/badge.svg)
-[![codecov](https://codecov.io/gh/aleaf/modflow-setup/branch/master/graph/badge.svg)](https://codecov.io/gh/usgs/modflow-setup)
+[![codecov](https://codecov.io/gh/usgs/modflow-setup/branch/develop/graph/badge.svg?token=aWN47DYeIv)](https://codecov.io/gh/usgs/modflow-setup)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/usgs/modflow-setup/develop?urlpath=lab/tree/examples)
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 

--- a/mfsetup/tests/test_mf6_shellmound.py
+++ b/mfsetup/tests/test_mf6_shellmound.py
@@ -930,10 +930,15 @@ def test_model_setup_and_run(model_setup_and_run):
     assert not (m.model_ws / m.cfg['intermediate_data']['output_folder']).exists()
 
 
-def test_load(model_setup, shellmound_cfg_path):
+@pytest.mark.parametrize('load_only', (None, ['dis']))
+def test_load(model_setup, shellmound_cfg_path, load_only):
     m = model_setup  #deepcopy(pfl_nwt_setup_from_yaml)
-    m2 = MF6model.load_from_config(shellmound_cfg_path)
-    assert m == m2
+    m2 = MF6model.load_from_config(shellmound_cfg_path,
+                                   load_only=load_only)
+    if load_only is None:
+        assert m == m2
+    else:
+        assert m2.get_package_list() == ['DIS']
 
 
 def test_packagelist(shellmound_cfg_path):

--- a/mfsetup/tests/test_tmr.py
+++ b/mfsetup/tests/test_tmr.py
@@ -56,8 +56,6 @@ def test_get_qx_qy_qz(tmpdir, parent_model_mf6, parent_model_nwt, specific_disch
     m6 = parent_model_mf6
     qx6, qy6, qz6 = get_qx_qy_qz(mf6_ws / 'tmr_parent.cbc', binary_grid_file=mf6_ws / 'tmr_parent.dis.grb',
                                 version='mf6',
-                                model_top=m6.dis.top.array,
-                                model_bottom_array=m6.dis.botm.array,
                                 specific_discharge=specific_discharge,
                                 modelgrid=m6.modelgrid,
                                 headfile=mf6_ws / 'tmr_parent.hds')
@@ -69,8 +67,6 @@ def test_get_qx_qy_qz(tmpdir, parent_model_mf6, parent_model_nwt, specific_disch
     mnwt = parent_model_nwt
     qxnwt, qynwt, qznwt = get_qx_qy_qz(mfnwt_ws / 'tmr_parent_nwt.cbc',
                                        version='mfnwt',
-                                       model_top=mnwt.dis.top.array,
-                                       model_bottom_array=mnwt.dis.botm.array,
                                        specific_discharge=specific_discharge,
                                        modelgrid=mnwt.modelgrid,
                                        headfile=mfnwt_ws / 'tmr_parent_nwt.hds')


### PR DESCRIPTION
…luxes

* move get_intercell_connections to grid module, and seperate from flow reading so it only has to be done once
* commented out extra intantiation of Interpolator (both x and y fluxes now interpolate to the same grid)
* profiled get_qx_qy_qz; reading the flows from the cell budget file takes up almost all of the execution time, so further reduction would require changes to the flopy binary grid reader
* current configuration took ~45 minutes to get boundary fluxes for the delta model (605 x 270; 21 layers)