### PR TITLE
feat(pyproject.toml): add PEP 518 support, use "python -m build"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,7 +10,7 @@ include versioneer.py
 include mfsetup/_version.py
 include mfsetup/mfnwt_defaults.yml
 include mfsetup/mf6_defaults.yml
-include mfsetup/data/shellmound.yml
+include mfsetup/tests/data/shellmound.yml
 
 # If including data files in the package, add them like:
 # include path/to/data_file

--- a/make_release.sh
+++ b/make_release.sh
@@ -17,8 +17,8 @@ echo "removing kruft..."
 #git clean -dfx
 
 echo "making the wheel..."
-python setup.py sdist
-python setup.py bdist_wheel
+python -m build
 
 echo "uploading to PyPI..."
+twine check --strict dist/*
 twine upload dist/* --cert ~/cert.pem

--- a/mfsetup/tests/conftest.py
+++ b/mfsetup/tests/conftest.py
@@ -31,7 +31,7 @@ def project_root_path():
 
 @pytest.fixture(scope="session")
 def test_data_path(project_root_path):
-    """Root folder for the project (with setup.py),
+    """Root folder for the project (with pyproject.toml),
     two levels up from the location of this file.
     """
     return Path(project_root_path, 'mfsetup', 'tests', 'data')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.isort]
+default_section = "THIRDPARTY"
+known_first_party = ["xarray"]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,12 +5,3 @@ versionfile_source = mfsetup/_version.py
 versionfile_build = mfsetup/_version.py
 tag_prefix = v
 parentdir_prefix = modflow-setup-
-
-[isort]
-default_section = THIRDPARTY
-known_first_party = xarray
-multi_line_output = 3
-include_trailing_comma = True
-force_grid_wrap = 0
-use_parentheses = True
-line_length = 88

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,12 @@ from os import path
 
 from setuptools import find_packages, setup
 
-import versioneer
+# ensure the current directory is on sys.path so versioneer can be imported
+# when pip uses PEP 517/518 build rules.
+# https://github.com/python-versioneer/python-versioneer/issues/193
+sys.path.append(path.dirname(__file__))
+
+import versioneer  # noqa: E402
 
 # NOTE: This file must remain Python 2 compatible for the foreseeable future,
 # to ensure that we error out properly for people with outdated setuptools
@@ -40,6 +45,7 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     description="Package to facilitate setup of a MODFLOW-6 groundwater flow model with the SFR package.",
     long_description=readme,
+    long_description_content_type='text/markdown',
     author="USGS MAP Project",
     author_email='aleaf@usgs.gov',
     url='https://github.com/aleaf/modflow-setup',


### PR DESCRIPTION
This enhancement adds a `pyproject.toml` file to specify build system dependencies to comply with [PEP 518](https://peps.python.org/pep-0518/).

Wheel and sdist package files can be built using `python -m build` ([docs](https://pypa-build.readthedocs.io/en/stable/index.html)).

Other changes:

- Add `twine check --strict` to check packages before upload to PyPI, which would have been broken apart from the next fix...
- Fix packaging `long_description` by specifying content type as `text/markdown`
- Correction to path to file specified in `MANIFEST.in`
- Move isort options from `setup.cfg` to more preferred `pyproject.toml`